### PR TITLE
Use is_numeric instead of ctype_digit to validate numeric type

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -124,7 +124,7 @@ class CreditCard
 
     public static function validCvc($cvc, $type)
     {
-        return (ctype_digit($cvc) && array_key_exists($type, self::$cards) && self::validCvcLength($cvc, $type));
+        return (is_numeric($cvc) && array_key_exists($type, self::$cards) && self::validCvcLength($cvc, $type));
     }
 
     public static function validDate($year, $month)


### PR DESCRIPTION
Using ctype_digit doesn't work as expected. For example for the CVC of 243 which is valid it returns false. Using is_numeric is more appropriate in this case.
