### PR TITLE
Make CreditCard::creditCardType() public.

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -147,10 +147,7 @@ class CreditCard
         return true;
     }
 
-    // PROTECTED
-    // ---------------------------------------------------------
-
-    protected static function creditCardType($number)
+    public static function creditCardType($number)
     {
         foreach (self::$cards as $type => $card) {
             if (preg_match($card['pattern'], $number)) {
@@ -160,6 +157,9 @@ class CreditCard
 
         return '';
     }
+
+    // PROTECTED
+    // ---------------------------------------------------------
 
     protected static function validCard($number, $type)
     {


### PR DESCRIPTION
Payment gateway APIs require the credit card type in request parameters but why prompt users in the UI to select it when Visa, Amex, etc. can be automatically recognized at the time of performing auth or capture? `validCreditCard()` with `$type` as input is useful if the CC details are being stored now without pre-auth until a later date when e.g., a subscription renewal occurs. Otherwise let the payment gateway reject the card number.

Combined with https://github.com/inacho/php-credit-card-validator/pull/4 this will add credit card recognition so the correct type can be submitted to payment gateway APIs.

``` php
public function getTypeForGateway($type)
{
    CreditCard::TYPE_AMEX:
        return 'Amex constant specific for that payment API';

        break;
    CreditCard::TYPE_DANKORT:
    CreditCard::TYPE_DINERS_CLUB:
    CreditCard::TYPE_DISCOVER:
    CreditCard::TYPE_FORBRUGSFORENINGEN:
    CreditCard::TYPE_JCB:
    CreditCard::TYPE_MAESTRO:
    CreditCard::TYPE_MASTERCARD:
    CreditCard::TYPE_UNION_PAY:
    CreditCard::TYPE_VISA:
    CreditCard::TYPE_VISA_ELECTRON:
        // etc.

        break;
}

public function auth($creditCard)
{
    $payloadForApi = [
        'type' = $this->getTypeForGateway(CreditCard::creditCardType($creditCard->number));

        // ...
    ];

}
```

For one use case I ended up creating an intermediate wrapper class:

``` php
class InachoCreditCard extends \Inacho\CreditCard
{
    public static function getCardType($number)
    {
        $type = strtoupper(static::creditCardType($number));

        // CreditCardType contains constants for Moneris
        if (CreditCardType::isValidValue($type)) {
            return $type;
        }

        return null;
    }
}
```
