### PR TITLE
php7.4 compatibility

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -12,7 +12,7 @@ namespace Inacho;
 
 class CreditCard
 {
-    protected static $cards = array(
+    protected static array $cards = array(
         // Debit cards must come first, since they have more specific patterns than their credit-card equivalents.
 
         'visaelectron' => array(
@@ -206,12 +206,12 @@ class CreditCard
     {
         $checksum = 0;
         for ($i=(2-(strlen($number) % 2)); $i<=strlen($number); $i+=2) {
-            $checksum += (int) ($number{$i-1});
+            $checksum += (int) ($number[$i-1]);
         }
 
         // Analyze odd digits in even length strings or even digits in odd length strings.
         for ($i=(strlen($number)% 2) + 1; $i<strlen($number); $i+=2) {
-            $digit = (int) ($number{$i-1}) * 2;
+            $digit = (int) ($number[$i-1]) * 2;
             if ($digit < 10) {
                 $checksum += $digit;
             } else {
@@ -219,10 +219,7 @@ class CreditCard
             }
         }
 
-        if (($checksum % 10) == 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return (($checksum % 10) == 0);
+
     }
 }

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -12,7 +12,7 @@ namespace Inacho;
 
 class CreditCard
 {
-    protected static array $cards = array(
+    protected static $cards = array(
         // Debit cards must come first, since they have more specific patterns than their credit-card equivalents.
 
         'visaelectron' => array(


### PR DESCRIPTION
fixes this error with PHP 7.4:  Array and string offset access syntax with curly braces is deprecated {"exception":"[object] (ErrorException(code: 0): Array and string offset access syntax with curly braces is deprecated at /var/www/vendor/inacho/php-credit-card-validator/src/CreditCard.php:209