### PR TITLE
syntax with curly braces is deprecated

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -206,12 +206,12 @@ class CreditCard
     {
         $checksum = 0;
         for ($i=(2-(strlen($number) % 2)); $i<=strlen($number); $i+=2) {
-            $checksum += (int) ($number{$i-1});
+            $checksum += (int) ($number[$i-1]);
         }
 
         // Analyze odd digits in even length strings or even digits in odd length strings.
         for ($i=(strlen($number)% 2) + 1; $i<strlen($number); $i+=2) {
-            $digit = (int) ($number{$i-1}) * 2;
+            $digit = (int) ($number[$i-1]) * 2;
             if ($digit < 10) {
                 $checksum += $digit;
             } else {


### PR DESCRIPTION
PHP Deprecated: Array and string offset access syntax with curly braces is deprecated